### PR TITLE
Add project-wide Metadata Items

### DIFF
--- a/examples/compute/project-metadata-item.gyro
+++ b/examples/compute/project-metadata-item.gyro
@@ -1,0 +1,9 @@
+google::project-metadata-item project-metadata-item-example
+    key: "example-key"
+    value: "example-value"
+end
+
+google::project-metadata-item project-ssh-keys-example
+    key: "ssh-keys"
+    value: "[USERNAME_1]:ssh-rsa [SSH_KEY_1] [USERNAME_1]\n[USERNAME_2]:ssh-rsa [SSH_KEY_2] [USERNAME_2]"
+end

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
@@ -66,23 +66,21 @@ public class ProjectMetadataItemFinder extends GoogleFinder<Compute, Metadata.It
 
     @Override
     protected List<Metadata.Items> findGoogle(Compute client, Map<String, String> filters) {
-        Metadata.Items item;
-
         try {
-            item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
+            Metadata.Items item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
                 .filter(r -> filters.get("name").equals(r.getKey()))
                 .findFirst()
                 .orElse(null);
+
+            if (item != null) {
+                return Collections.singletonList(item);
+            } else {
+                return Collections.emptyList();
+            }
         } catch (GoogleJsonResponseException je) {
             throw new GyroException(je.getDetails().getMessage());
         } catch (IOException ex) {
             throw new GyroException(ex);
-        }
-
-        if (item != null) {
-            return Collections.singletonList(item);
-        } else {
-            return Collections.emptyList();
         }
     }
 }

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
@@ -68,7 +68,7 @@ public class ProjectMetadataItemFinder extends GoogleFinder<Compute, Metadata.It
     protected List<Metadata.Items> findGoogle(Compute client, Map<String, String> filters) {
         try {
             Metadata.Items item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
-                .filter(r -> filters.get("name").equals(r.getKey()))
+                .filter(r -> filters.get("key").equals(r.getKey()))
                 .findFirst()
                 .orElse(null);
 

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.google.compute;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Metadata;
+import gyro.core.GyroException;
+import gyro.core.Type;
+import gyro.google.GoogleFinder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Query a project-wide metadata item.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *    project-metadata-item: $(external-query google::project-metadata-item { key: 'example-key'})
+ */
+@Type("project-metadata-item")
+public class ProjectMetadataItemFinder extends GoogleFinder<Compute, Metadata.Items, ProjectMetadataItemResource> {
+    private String key;
+
+    /**
+     * The key of the metadata item.
+     */
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    protected List<Metadata.Items> findAllGoogle(Compute client) {
+        try {
+            return client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems();
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(je.getDetails().getMessage());
+        } catch (IOException ex) {
+            throw new GyroException(ex);
+        }
+    }
+
+    @Override
+    protected List<Metadata.Items> findGoogle(Compute client, Map<String, String> filters) {
+        Metadata.Items item;
+
+        try {
+            item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
+                .filter(r -> filters.get("name").equals(r.getKey()))
+                .findFirst()
+                .orElse(null);
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(je.getDetails().getMessage());
+        } catch (IOException ex) {
+            throw new GyroException(ex);
+        }
+
+        if (item != null) {
+            return Collections.singletonList(item);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -29,7 +29,6 @@ import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
 import gyro.core.validation.Required;
 import gyro.google.Copyable;
-
 import java.util.List;
 import java.util.Set;
 
@@ -83,7 +82,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
 
     @Override
     public boolean refresh() {
-        Compute client = creatClient(Compute.class);
+        Compute client = createComputeClient();
 
         Metadata metadata = getMetadata(client);
         Metadata.Items item = metadata.getItems()
@@ -103,7 +102,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
 
     @Override
     public void create(GyroUI ui, State state) {
-        Compute client = creatClient(Compute.class);
+        Compute client = createComputeClient();
 
         Metadata.Items item = new Metadata.Items();
         item.setKey(getKey());
@@ -119,7 +118,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        Compute client = creatClient(Compute.class);
+        Compute client = createComputeClient();
 
         Metadata metadata = getMetadata(client);
         Metadata.Items item = metadata.getItems()
@@ -136,7 +135,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
 
     @Override
     public void delete(GyroUI ui, State state) {
-        Compute client = creatClient(Compute.class);
+        Compute client = createComputeClient();
 
         Metadata metadata = getMetadata(client);
         metadata.getItems().removeIf(r -> getKey().equals(r.getKey()));

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.google.compute;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Project;
+import gyro.core.GyroException;
+import gyro.core.GyroUI;
+import gyro.core.Type;
+import gyro.core.resource.Resource;
+import gyro.core.resource.Updatable;
+import gyro.core.scope.State;
+import gyro.core.validation.Required;
+import gyro.google.Copyable;
+
+/**
+ * Creates a project-wide metadata item. Set project-wide SSH keys by creating an item with the key ``ssh-keys``.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *     google::project-metadata-item project-metadata-item-example
+ *         key: "example-key"
+ *         value: "example-value"
+ *     end
+ */
+@Type("project-metadata-item")
+public class ProjectMetadataItemResource extends ComputeResource implements Copyable<Metadata.Items> {
+    private String key;
+    private String value;
+
+    @Required
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @Updatable
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public void copyFrom(Metadata.Items metadataItem) {
+        setKey(metadataItem.getKey());
+        setValue(metadataItem.getValue());
+    }
+
+    @Override
+    public boolean refresh() {
+        Compute client = creatClient(Compute.class);
+        Metadata metadata = getMetadata(client);
+        Metadata.Items item = metadata.getItems()
+            .stream()
+            .filter(r -> getKey().equals(r.getKey()))
+            .findFirst()
+            .orElse(null);
+        if (item != null) {
+            copyFrom(item);
+
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void create(GyroUI ui, State state) {
+        Compute client = creatClient(Compute.class);
+
+        Metadata.Items item = new Metadata.Items();
+        item.setKey(getKey());
+        item.setValue(getValue());
+
+        Metadata metadata = getMetadata(client);
+        List<Metadata.Items> items = metadata.getItems();
+        items.add(item);
+        metadata.setItems(items);
+
+        setMetadata(client, metadata);
+    }
+
+    @Override
+    public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
+        Compute client = creatClient(Compute.class);
+
+        Metadata metadata = getMetadata(client);
+        Metadata.Items item = metadata.getItems()
+            .stream()
+            .filter(r -> getKey().equals(r.getKey()))
+            .findFirst()
+            .orElse(null);
+
+        if (item != null) {
+            item.setValue(getValue());
+            setMetadata(client, metadata);
+        }
+
+    }
+
+    @Override
+    public void delete(GyroUI ui, State state) {
+        Compute client = creatClient(Compute.class);
+
+        Metadata metadata = getMetadata(client);
+        metadata.getItems().removeIf(r -> getKey().equals(r.getKey()));
+
+        setMetadata(client, metadata);
+    }
+
+    private Metadata getMetadata(Compute client) {
+        try {
+            Compute.Projects.Get projectRequest = client.projects().get(getProjectId());
+            Project project = projectRequest.execute();
+            return project.getCommonInstanceMetadata();
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    private void setMetadata(Compute client, Metadata metadata) {
+        try {
+            Compute.Projects.SetCommonInstanceMetadata metadataRequest =
+                client.projects().setCommonInstanceMetadata(getProjectId(), metadata);
+            Operation operation = metadataRequest.execute();
+
+            Operation.Error error = waitForCompletion(client, operation);
+            if (error != null) {
+                throw new GyroException(error.toPrettyString());
+            }
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(je.getDetails().getMessage());
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+}

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -16,7 +16,6 @@
 
 package gyro.google.compute;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -52,6 +51,9 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     private String key;
     private String value;
 
+    /**
+     * The key of the metadata item. (Required)
+     */
     @Required
     public String getKey() {
         return key;
@@ -61,6 +63,9 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
         this.key = key;
     }
 
+    /**
+     * The value of the metadata item.
+     */
     @Updatable
     public String getValue() {
         return value;
@@ -79,17 +84,20 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     @Override
     public boolean refresh() {
         Compute client = creatClient(Compute.class);
+
         Metadata metadata = getMetadata(client);
         Metadata.Items item = metadata.getItems()
             .stream()
             .filter(r -> getKey().equals(r.getKey()))
             .findFirst()
             .orElse(null);
+
         if (item != null) {
             copyFrom(item);
 
             return true;
         }
+
         return false;
     }
 
@@ -124,7 +132,6 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
             item.setValue(getValue());
             setMetadata(client, metadata);
         }
-
     }
 
     @Override
@@ -141,6 +148,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
         try {
             Compute.Projects.Get projectRequest = client.projects().get(getProjectId());
             Project project = projectRequest.execute();
+
             return project.getCommonInstanceMetadata();
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -52,7 +52,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     private String value;
 
     /**
-     * The key of the metadata item. (Required)
+     * The key of the metadata item. Allowed characters include letters, digits, ``-``, and ``_``. (Required)
      */
     @Required
     public String getKey() {
@@ -150,6 +150,8 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
             Project project = projectRequest.execute();
 
             return project.getCommonInstanceMetadata();
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(je.getDetails().getMessage());
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -16,9 +16,6 @@
 
 package gyro.google.compute;
 
-import java.util.List;
-import java.util.Set;
-
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Metadata;
@@ -32,6 +29,9 @@ import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
 import gyro.core.validation.Required;
 import gyro.google.Copyable;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * Creates a project-wide metadata item. Set project-wide SSH keys by creating an item with the key ``ssh-keys``.
@@ -166,7 +166,12 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
                 throw new GyroException(error.toPrettyString());
             }
         } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
+            String message = je.getDetails().getMessage();
+            if (message.contains("Metadata has duplicate keys")) {
+                throw new GyroException(String.format("Duplicate keys: %s", getKey()));
+            }
+
+            throw new GyroException(message);
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }


### PR DESCRIPTION
Fixes #17: This PR adds project wide metadata items, which can be used to set the `ssh-keys` metadata item.