### PR TITLE
GCP: All compute operations should wait for successful execution

### DIFF
--- a/src/main/java/gyro/google/compute/AbstractDiskResource.java
+++ b/src/main/java/gyro/google/compute/AbstractDiskResource.java
@@ -287,10 +287,7 @@ public abstract class AbstractDiskResource extends ComputeResource implements Co
     private boolean executeCreateDisk(Compute client, ComputeRequest<Operation> insert) throws Exception {
         try {
             Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
         } catch (GoogleJsonResponseException je) {
             if (je.getDetails()
                 .getErrors()

--- a/src/main/java/gyro/google/compute/AddressResource.java
+++ b/src/main/java/gyro/google/compute/AddressResource.java
@@ -22,7 +22,6 @@ import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Address;
-import com.google.api.services.compute.model.Operation;
 import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
@@ -105,13 +104,9 @@ public class AddressResource extends AbstractAddressResource {
     @Override
     public void doDelete(GyroUI ui, State state) throws Exception {
         Compute compute = createClient(Compute.class);
-        Operation.Error error = waitForCompletion(
+        waitForCompletion(
             compute,
             compute.addresses().delete(getProjectId(), getRegion(), getName()).execute());
-
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
     }
 
     @Override
@@ -127,12 +122,9 @@ public class AddressResource extends AbstractAddressResource {
 
     private boolean createAddress(Compute compute, Address address) throws Exception {
         try {
-            Operation.Error error = waitForCompletion(
+            waitForCompletion(
                 compute,
                 compute.addresses().insert(getProjectId(), getRegion(), address).execute());
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
         } catch (GoogleJsonResponseException e) {
             if (e.getDetails()
                 .getErrors()

--- a/src/main/java/gyro/google/compute/ComputeResource.java
+++ b/src/main/java/gyro/google/compute/ComputeResource.java
@@ -19,15 +19,16 @@ package gyro.google.compute;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Operation;
+import gyro.core.GyroException;
 import gyro.google.GoogleResource;
 
 public abstract class ComputeResource extends GoogleResource {
 
-    public Operation.Error waitForCompletion(Compute compute, Operation operation) throws Exception {
-        return waitForCompletion(compute, operation, 60000);
+    public void waitForCompletion(Compute compute, Operation operation) throws Exception {
+        waitForCompletion(compute, operation, 60000);
     }
 
-    public Operation.Error waitForCompletion(Compute compute, Operation operation, long timeout) throws Exception {
+    public void waitForCompletion(Compute compute, Operation operation, long timeout) throws Exception {
         long start = System.currentTimeMillis();
         final long pollInterval = 1000;
 
@@ -55,14 +56,14 @@ public abstract class ComputeResource extends GoogleResource {
                 }
             }
         } catch (GoogleJsonResponseException ex) {
-            if (ex.getStatusCode() == 404) {
-                return null;
+            if (ex.getStatusCode() != 404) {
+                throw ex;
             }
-
-            throw ex;
         }
 
-        return operation == null ? null : operation.getError();
+        if (operation != null) {
+            throw new GyroException(operation.getError().toPrettyString());
+        }
     }
 
 }

--- a/src/main/java/gyro/google/compute/DiskResource.java
+++ b/src/main/java/gyro/google/compute/DiskResource.java
@@ -135,10 +135,7 @@ public class DiskResource extends AbstractDiskResource {
         Compute client = createComputeClient();
 
         Operation operation = client.disks().delete(getProjectId(), getZone(), getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     private void saveSizeGb(Compute client, DiskResource oldDiskResource) throws Exception {
@@ -151,10 +148,7 @@ public class DiskResource extends AbstractDiskResource {
         DisksResizeRequest resizeRequest = new DisksResizeRequest();
         resizeRequest.setSizeGb(getSizeGb());
         Operation operation = client.disks().resize(getProjectId(), getZone(), getName(), resizeRequest).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     private void saveLabels(Compute client) throws Exception {
@@ -162,10 +156,7 @@ public class DiskResource extends AbstractDiskResource {
         labelsRequest.setLabels(getLabels());
         labelsRequest.setLabelFingerprint(getLabelFingerprint());
         Operation operation = client.disks().setLabels(getProjectId(), getZone(), getName(), labelsRequest).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     static ProjectZoneDiskName parseDisk(String projectId, String selfLink) {

--- a/src/main/java/gyro/google/compute/FirewallResource.java
+++ b/src/main/java/gyro/google/compute/FirewallResource.java
@@ -28,7 +28,6 @@ import com.google.api.services.compute.model.Firewall;
 import com.google.api.services.compute.model.FirewallLogConfig;
 import com.google.api.services.compute.model.Operation;
 import com.google.cloud.compute.v1.ProjectGlobalNetworkName;
-import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
 import gyro.core.resource.Id;
@@ -434,10 +433,7 @@ public class FirewallResource extends ComputeResource implements Copyable<Firewa
 
         Compute.Firewalls.Insert insert = client.firewalls().insert(getProjectId(), toFirewall());
         Operation operation = insert.execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -447,10 +443,7 @@ public class FirewallResource extends ComputeResource implements Copyable<Firewa
         Compute client = createComputeClient();
 
         Operation operation = client.firewalls().patch(getProjectId(), getName(), toFirewall()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -460,10 +453,7 @@ public class FirewallResource extends ComputeResource implements Copyable<Firewa
         Compute client = createComputeClient();
 
         Operation operation = client.firewalls().delete(getProjectId(), getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     @Override

--- a/src/main/java/gyro/google/compute/GlobalAddressResource.java
+++ b/src/main/java/gyro/google/compute/GlobalAddressResource.java
@@ -18,8 +18,6 @@ package gyro.google.compute;
 
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Address;
-import com.google.api.services.compute.model.Operation;
-import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
 import gyro.core.scope.State;
@@ -72,22 +70,15 @@ public class GlobalAddressResource extends AbstractAddressResource {
     public void doCreate(GyroUI ui, State state) throws Exception {
         Compute compute = createClient(Compute.class);
         Address address = copyTo().setIpVersion(getIpVersion());
-        Operation.Error error = waitForCompletion(compute, compute.globalAddresses().insert(getProjectId(), address).execute());
+        waitForCompletion(compute, compute.globalAddresses().insert(getProjectId(), address).execute());
 
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
         refresh();
     }
 
     @Override
     public void doDelete(GyroUI ui, State state) throws Exception {
         Compute compute = createClient(Compute.class);
-        Operation.Error error = waitForCompletion(compute, compute.globalAddresses().delete(getProjectId(), getName()).execute());
-
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(compute, compute.globalAddresses().delete(getProjectId(), getName()).execute());
     }
 
     @Override

--- a/src/main/java/gyro/google/compute/HealthCheckResource.java
+++ b/src/main/java/gyro/google/compute/HealthCheckResource.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.HealthCheck;
 import com.google.api.services.compute.model.Operation;
-import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
 import gyro.core.resource.Resource;
@@ -130,10 +129,7 @@ public class HealthCheckResource extends AbstractHealthCheckResource {
         HealthCheck healthCheck = getHealthCheck(null);
         Compute.HealthChecks.Insert insert = client.healthChecks().insert(getProjectId(), healthCheck);
         Operation operation = insert.execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -143,10 +139,7 @@ public class HealthCheckResource extends AbstractHealthCheckResource {
         Compute client = createComputeClient();
         HealthCheck healthCheck = getHealthCheck(changedFieldNames);
         Operation operation = client.healthChecks().patch(getProjectId(), getName(), healthCheck).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -156,9 +149,6 @@ public class HealthCheckResource extends AbstractHealthCheckResource {
         Compute client = createComputeClient();
         HealthCheck healthCheck = client.healthChecks().get(getProjectId(), getName()).execute();
         Operation operation = client.healthChecks().delete(getProjectId(), healthCheck.getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 }

--- a/src/main/java/gyro/google/compute/InstanceGroupResource.java
+++ b/src/main/java/gyro/google/compute/InstanceGroupResource.java
@@ -25,7 +25,6 @@ import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.InstanceGroup;
 import com.google.api.services.compute.model.InstanceGroupsSetNamedPortsRequest;
 import com.google.api.services.compute.model.Operation;
-import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
 import gyro.core.resource.Id;
@@ -190,10 +189,7 @@ public class InstanceGroupResource extends ComputeResource implements Copyable<I
     public void doCreate(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
         Operation operation = client.instanceGroups().insert(getProjectId(), getZone(), toInstanceGroup()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         state.save();
 
@@ -215,10 +211,7 @@ public class InstanceGroupResource extends ComputeResource implements Copyable<I
     public void doDelete(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
         Operation operation = client.instanceGroups().delete(getProjectId(), getZone(), getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     @Override
@@ -273,9 +266,6 @@ public class InstanceGroupResource extends ComputeResource implements Copyable<I
         Operation operation = client.instanceGroups()
             .setNamedPorts(getProjectId(), getZone(), getName(), namedPortsRequest)
             .execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 }

--- a/src/main/java/gyro/google/compute/NetworkResource.java
+++ b/src/main/java/gyro/google/compute/NetworkResource.java
@@ -153,12 +153,11 @@ public class NetworkResource extends ComputeResource implements Copyable<Network
         try {
             Compute.Networks.Insert insert = client.networks().insert(getProjectId(), network);
             Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
 
             refresh();
+        } catch (GyroException ge) {
+            throw ge;
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }
@@ -175,20 +174,27 @@ public class NetworkResource extends ComputeResource implements Copyable<Network
             Network network = client.networks().get(getProjectId(), getName()).execute();
             network.setRoutingConfig(networkRoutingConfig);
 
-            client.networks().patch(getProjectId(), getName(), network).execute();
+            Operation operation = client.networks().patch(getProjectId(), getName(), network).execute();
+            waitForCompletion(client, operation);
+
             refresh();
-        } catch (IOException ex) {
+        } catch (GyroException ge) {
+            throw ge;
+        } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }
     }
 
     @Override
     public void delete(GyroUI ui, State state) {
-        Compute compute = creatClient(Compute.class);
+        Compute client = creatClient(Compute.class);
 
         try {
-            compute.networks().delete(getProjectId(), getName()).execute();
-        } catch (IOException ex) {
+            Operation operation = client.networks().delete(getProjectId(), getName()).execute();
+            waitForCompletion(client, operation);
+        } catch (GyroException ge) {
+            throw ge;
+        } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }
     }

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -158,10 +158,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
                 client.projects().setCommonInstanceMetadata(getProjectId(), metadata);
             Operation operation = metadataRequest.execute();
 
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
         } catch (GoogleJsonResponseException je) {
             String message = je.getDetails().getMessage();
             if (message.contains("Metadata has duplicate keys")) {

--- a/src/main/java/gyro/google/compute/RegionDiskResource.java
+++ b/src/main/java/gyro/google/compute/RegionDiskResource.java
@@ -185,10 +185,7 @@ public class RegionDiskResource extends AbstractDiskResource {
         Compute client = createComputeClient();
 
         Operation operation = client.regionDisks().delete(getProjectId(), getRegion(), getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     @Override
@@ -217,10 +214,7 @@ public class RegionDiskResource extends AbstractDiskResource {
         Operation operation = client.regionDisks()
             .resize(getProjectId(), getRegion(), getName(), resizeRequest)
             .execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     private void saveLabels(Compute client) throws Exception {
@@ -230,10 +224,7 @@ public class RegionDiskResource extends AbstractDiskResource {
         Operation operation = client.regionDisks()
             .setLabels(getProjectId(), getRegion(), getName(), labelsRequest)
             .execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     static ProjectRegionDiskName parseRegionDisk(String projectId, String selfLink) {

--- a/src/main/java/gyro/google/compute/RegionalHealthCheckResource.java
+++ b/src/main/java/gyro/google/compute/RegionalHealthCheckResource.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.HealthCheck;
 import com.google.api.services.compute.model.Operation;
-import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
 import gyro.core.resource.Resource;
@@ -141,10 +140,7 @@ public class RegionalHealthCheckResource extends AbstractHealthCheckResource {
         Compute.RegionHealthChecks.Insert insert = client.regionHealthChecks()
             .insert(getProjectId(), healthCheck.getRegion(), healthCheck);
         Operation operation = insert.execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -161,11 +157,7 @@ public class RegionalHealthCheckResource extends AbstractHealthCheckResource {
         Operation operation = client.regionHealthChecks()
             .patch(getProjectId(), getRegion(), getName(), healthCheck)
             .execute();
-        Operation.Error error = waitForCompletion(client, operation);
-
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -177,9 +169,6 @@ public class RegionalHealthCheckResource extends AbstractHealthCheckResource {
         Operation operation = client.regionHealthChecks()
             .delete(getProjectId(), region, healthCheck.getName())
             .execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 }

--- a/src/main/java/gyro/google/compute/RouteResource.java
+++ b/src/main/java/gyro/google/compute/RouteResource.java
@@ -29,7 +29,6 @@ import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Route;
 import com.google.cloud.compute.v1.ProjectGlobalNetworkName;
 import gyro.core.GyroCore;
-import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.Type;
 import gyro.core.resource.Output;
@@ -251,10 +250,7 @@ public class RouteResource extends ComputeResource implements Copyable<Route> {
         route.setTags(new ArrayList<>(getTags()));
 
         Operation operation = client.routes().insert(getProjectId(), route).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         route = client.routes().get(getProjectId(), getName()).execute();
         copyFrom(route);
@@ -275,10 +271,7 @@ public class RouteResource extends ComputeResource implements Copyable<Route> {
         Compute client = createComputeClient();
 
         Operation operation = client.routes().delete(getProjectId(), getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     @Override

--- a/src/main/java/gyro/google/compute/SnapshotResource.java
+++ b/src/main/java/gyro/google/compute/SnapshotResource.java
@@ -343,10 +343,7 @@ public class SnapshotResource extends ComputeResource implements Copyable<Snapsh
             Compute.Disks.CreateSnapshot insert =
                 client.disks().createSnapshot(getProjectId(), zoneDisk.getZone(), zoneDisk.getDisk(), snapshot);
             Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
 
             refresh();
         } else if (getSourceRegionDisk() != null) {
@@ -361,10 +358,7 @@ public class SnapshotResource extends ComputeResource implements Copyable<Snapsh
             Compute.RegionDisks.CreateSnapshot insert = client.regionDisks()
                 .createSnapshot(getProjectId(), regionDisk.getRegion(), regionDisk.getDisk(), snapshot);
             Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
 
             refresh();
         }
@@ -378,10 +372,7 @@ public class SnapshotResource extends ComputeResource implements Copyable<Snapsh
         labelsRequest.setLabels(getLabels());
         labelsRequest.setLabelFingerprint(getLabelFingerprint());
         Operation operation = client.snapshots().setLabels(getProjectId(), getName(), labelsRequest).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
 
         refresh();
     }
@@ -391,10 +382,7 @@ public class SnapshotResource extends ComputeResource implements Copyable<Snapsh
         Compute client = createComputeClient();
 
         Operation operation = client.snapshots().delete(getProjectId(), getName()).execute();
-        Operation.Error error = waitForCompletion(client, operation);
-        if (error != null) {
-            throw new GyroException(error.toPrettyString());
-        }
+        waitForCompletion(client, operation);
     }
 
     @Override

--- a/src/main/java/gyro/google/compute/SubnetworkResource.java
+++ b/src/main/java/gyro/google/compute/SubnetworkResource.java
@@ -214,12 +214,11 @@ public class SubnetworkResource extends ComputeResource implements Copyable<Subn
         try {
             Compute.Subnetworks.Insert insert = client.subnetworks().insert(getProjectId(), getRegion(), subnetwork);
             Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
 
             refresh();
+        } catch (GyroException ge) {
+            throw ge;
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }
@@ -233,15 +232,19 @@ public class SubnetworkResource extends ComputeResource implements Copyable<Subn
             if (changedFieldNames.contains("enable-flow-logs")) {
                 Subnetwork subnetwork = client.subnetworks().get(getProjectId(), getRegion(), getName()).execute();
                 subnetwork.setEnableFlowLogs(getEnableFlowLogs());
-                client.subnetworks().patch(getProjectId(), getRegion(), getName(), subnetwork).execute();
+                Operation operation = client.subnetworks().patch(getProjectId(), getRegion(), getName(), subnetwork).execute();
+                waitForCompletion(client, operation);
             }
 
             if (changedFieldNames.contains("private-ip-google-access")) {
                 SubnetworksSetPrivateIpGoogleAccessRequest flag = new SubnetworksSetPrivateIpGoogleAccessRequest();
                 flag.setPrivateIpGoogleAccess(getPrivateIpGoogleAccess());
-                client.subnetworks().setPrivateIpGoogleAccess(getProjectId(), getRegion(), getName(), flag).execute();
+                Operation operation = client.subnetworks().setPrivateIpGoogleAccess(getProjectId(), getRegion(), getName(), flag).execute();
+                waitForCompletion(client, operation);
             }
-        } catch (IOException ex) {
+        } catch (GyroException ge) {
+            throw ge;
+        } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }
     }
@@ -252,11 +255,9 @@ public class SubnetworkResource extends ComputeResource implements Copyable<Subn
 
         try {
             Operation operation = client.subnetworks().delete(getProjectId(), getRegion(), getName()).execute();
-
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+            waitForCompletion(client, operation);
+        } catch (GyroException ge) {
+            throw ge;
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }


### PR DESCRIPTION
Fixes #30 : 

Refactors the `WaitForCompletion` method to throw exception when error occurs, removing redundant code from resources that call this method and do the same.

Calls `WaitForCompletion` method upon all execution requests to check for successful operation completion.