### PR TITLE
Removes duplicated exception handling and standardizes messaging

### DIFF
--- a/src/main/java/gyro/google/GoogleFinder.java
+++ b/src/main/java/gyro/google/GoogleFinder.java
@@ -28,9 +28,8 @@ import com.psddev.dari.util.TypeDefinition;
 import gyro.core.GyroException;
 import gyro.core.finder.Finder;
 
-import static gyro.google.GoogleResource.formatGoogleExceptionMessage;
-
 public abstract class GoogleFinder<C extends AbstractGoogleJsonClient, M, R extends GoogleResource> extends Finder<R> {
+
     protected abstract List<M> findAllGoogle(C client) throws Exception;
 
     protected abstract List<M> findGoogle(C client, Map<String, String> filters) throws Exception;
@@ -44,7 +43,7 @@ public abstract class GoogleFinder<C extends AbstractGoogleJsonClient, M, R exte
         } catch (GyroException ex) {
             throw ex;
         } catch (GoogleJsonResponseException je) {
-            throw new GyroException(formatGoogleExceptionMessage(je));
+            throw new GyroException(GoogleResource.formatGoogleExceptionMessage(je));
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());
         }
@@ -54,15 +53,15 @@ public abstract class GoogleFinder<C extends AbstractGoogleJsonClient, M, R exte
     public List<R> find(Map<String, Object> filters) {
         try {
             return findGoogle(newClient(), convertFilters(filters)).stream()
-            .map(this::newResource)
-            .collect(Collectors.toList());
+                .map(this::newResource)
+                .collect(Collectors.toList());
         } catch (GyroException ex) {
             throw ex;
         } catch (GoogleJsonResponseException je) {
             if (je.getDetails().getCode() == 404) {
                 return Collections.emptyList();
             } else {
-                throw new GyroException(formatGoogleExceptionMessage(je));
+                throw new GyroException(GoogleResource.formatGoogleExceptionMessage(je));
             }
         } catch (Exception ex) {
             throw new GyroException(ex.getMessage(), ex.getCause());

--- a/src/main/java/gyro/google/GoogleResource.java
+++ b/src/main/java/gyro/google/GoogleResource.java
@@ -16,8 +16,16 @@
 
 package gyro.google;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.googleapis.services.json.AbstractGoogleJsonClient;
+import gyro.core.GyroException;
+import gyro.core.GyroUI;
 import gyro.core.resource.Resource;
+import gyro.core.scope.State;
 
 public abstract class GoogleResource extends Resource {
 
@@ -33,4 +41,73 @@ public abstract class GoogleResource extends Resource {
         return credentials(GoogleCredentials.class).getProjectId();
     }
 
+    protected abstract boolean doRefresh() throws Exception;
+
+    @Override
+    public final boolean refresh() {
+        try {
+            return doRefresh();
+        } catch (GyroException ex) {
+            throw ex;
+        } catch (GoogleJsonResponseException je) {
+            if (je.getDetails().getCode() != 404) {
+                return false;
+            } else {
+                throw new GyroException(formatGoogleExceptionMessage(je));
+            }
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    protected abstract void doCreate(GyroUI ui, State state) throws Exception;
+
+    @Override
+    public final void create(GyroUI ui, State state) {
+        try {
+            doCreate(ui, state);
+        } catch (GyroException ex) {
+            throw ex;
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(formatGoogleExceptionMessage(je));
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    public abstract void doUpdate(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception;
+
+    @Override
+    public final void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
+        try {
+            doUpdate(ui, state, current, changedFieldNames);
+        } catch (GyroException ex) {
+            throw ex;
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(formatGoogleExceptionMessage(je));
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    public abstract void doDelete(GyroUI ui, State state) throws Exception;
+
+    @Override
+    public final void delete(GyroUI ui, State state) {
+        try {
+            doDelete(ui, state);
+        } catch (GyroException ex) {
+            throw ex;
+        } catch (GoogleJsonResponseException je) {
+            throw new GyroException(formatGoogleExceptionMessage(je));
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    protected static String formatGoogleExceptionMessage(GoogleJsonResponseException je) {
+        return je.getDetails().getErrors().stream()
+            .map(GoogleJsonError.ErrorInfo::getMessage)
+            .collect(Collectors.joining("\n"));
+    }
 }

--- a/src/main/java/gyro/google/GoogleResource.java
+++ b/src/main/java/gyro/google/GoogleResource.java
@@ -75,7 +75,8 @@ public abstract class GoogleResource extends Resource {
         }
     }
 
-    public abstract void doUpdate(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception;
+    public abstract void doUpdate(GyroUI ui, State state, Resource current, Set<String> changedFieldNames)
+        throws Exception;
 
     @Override
     public final void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {

--- a/src/main/java/gyro/google/compute/FirewallFinder.java
+++ b/src/main/java/gyro/google/compute/FirewallFinder.java
@@ -16,19 +16,16 @@
 
 package gyro.google.compute;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.Firewall;
-import com.google.api.services.compute.model.FirewallList;
-import gyro.core.GyroException;
-import gyro.core.Type;
-import gyro.google.GoogleFinder;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Firewall;
+import com.google.api.services.compute.model.FirewallList;
+import gyro.core.Type;
+import gyro.google.GoogleFinder;
 
 /**
  * Query firewall rue.
@@ -56,44 +53,22 @@ public class FirewallFinder extends GoogleFinder<Compute, Firewall, FirewallReso
     }
 
     @Override
-    protected List<Firewall> findAllGoogle(Compute client) {
-        try {
-            List<Firewall> firewalls = new ArrayList<>();
-            FirewallList firewallList;
-            String nextPageToken = null;
+    protected List<Firewall> findAllGoogle(Compute client) throws Exception {
+        List<Firewall> firewalls = new ArrayList<>();
+        FirewallList firewallList;
+        String nextPageToken = null;
 
-            do {
-                firewallList = client.firewalls().list(getProjectId()).setPageToken(nextPageToken).execute();
-                firewalls.addAll(firewallList.getItems());
-                nextPageToken = firewallList.getNextPageToken();
-            } while (nextPageToken != null);
+        do {
+            firewallList = client.firewalls().list(getProjectId()).setPageToken(nextPageToken).execute();
+            firewalls.addAll(firewallList.getItems());
+            nextPageToken = firewallList.getNextPageToken();
+        } while (nextPageToken != null);
 
-            return firewalls;
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
+        return firewalls;
     }
 
     @Override
-    protected List<Firewall> findGoogle(Compute client, Map<String, String> filters) {
-        Firewall firewall = null;
-
-        try {
-            firewall = client.firewalls().get(getProjectId(), filters.get("name")).execute();
-        } catch (GoogleJsonResponseException je) {
-            if (je.getDetails().getCode() != 404) {
-                throw new GyroException(je.getDetails().getMessage());
-            }
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
-
-        if (firewall != null) {
-            return Collections.singletonList(firewall);
-        } else {
-            return Collections.emptyList();
-        }
+    protected List<Firewall> findGoogle(Compute client, Map<String, String> filters) throws Exception {
+        return Collections.singletonList(client.firewalls().get(getProjectId(), filters.get("name")).execute());
     }
 }

--- a/src/main/java/gyro/google/compute/NetworkFinder.java
+++ b/src/main/java/gyro/google/compute/NetworkFinder.java
@@ -16,19 +16,16 @@
 
 package gyro.google.compute;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.Network;
-import com.google.api.services.compute.model.NetworkList;
-import gyro.core.GyroException;
-import gyro.core.Type;
-import gyro.google.GoogleFinder;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Network;
+import com.google.api.services.compute.model.NetworkList;
+import gyro.core.Type;
+import gyro.google.GoogleFinder;
 
 /**
  * Query network.
@@ -56,44 +53,22 @@ public class NetworkFinder extends GoogleFinder<Compute, Network, NetworkResourc
     }
 
     @Override
-    protected List<Network> findAllGoogle(Compute client) {
-        try {
-            List<Network> networks = new ArrayList<>();
-            NetworkList networkList;
-            String nextPageToken = null;
-            
-            do {
-                networkList = client.networks().list(getProjectId()).setPageToken(nextPageToken).execute();
-                networks.addAll(networkList.getItems());
-                nextPageToken = networkList.getNextPageToken();
-            } while (nextPageToken != null);
+    protected List<Network> findAllGoogle(Compute client) throws Exception {
+        List<Network> networks = new ArrayList<>();
+        NetworkList networkList;
+        String nextPageToken = null;
 
-            return networks;
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
+        do {
+            networkList = client.networks().list(getProjectId()).setPageToken(nextPageToken).execute();
+            networks.addAll(networkList.getItems());
+            nextPageToken = networkList.getNextPageToken();
+        } while (nextPageToken != null);
+
+        return networks;
     }
 
     @Override
-    protected List<Network> findGoogle(Compute client, Map<String, String> filters) {
-        Network network = null;
-
-        try {
-            network = client.networks().get(getProjectId(), filters.get("name")).execute();
-        } catch (GoogleJsonResponseException je) {
-            if (!je.getDetails().getMessage().matches("The resource (.*) was not found")) {
-                throw new GyroException(je.getDetails().getMessage());
-            }
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
-
-        if (network != null) {
-            return Collections.singletonList(network);
-        } else {
-            return Collections.emptyList();
-        }
+    protected List<Network> findGoogle(Compute client, Map<String, String> filters) throws Exception {
+        return Collections.singletonList(client.networks().get(getProjectId(), filters.get("name")).execute());
     }
 }

--- a/src/main/java/gyro/google/compute/NetworkResource.java
+++ b/src/main/java/gyro/google/compute/NetworkResource.java
@@ -16,10 +16,8 @@
 
 package gyro.google.compute;
 
-import java.io.IOException;
 import java.util.Set;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Network;
 import com.google.api.services.compute.model.NetworkRoutingConfig;
@@ -118,27 +116,17 @@ public class NetworkResource extends ComputeResource implements Copyable<Network
     }
 
     @Override
-    public boolean refresh() {
+    public boolean doRefresh() throws Exception {
         Compute client = createComputeClient();
 
-        try {
-            Network network = client.networks().get(getProjectId(), getName()).execute();
-            copyFrom(network);
+        Network network = client.networks().get(getProjectId(), getName()).execute();
+        copyFrom(network);
 
-            return true;
-        } catch (GoogleJsonResponseException je) {
-            if (je.getDetails().getMessage().matches("The resource (.*) was not found")) {
-                return false;
-            } else {
-                throw new GyroException(je.getDetails().getMessage());
-            }
-        } catch (IOException ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
+        return true;
     }
 
     @Override
-    public void create(GyroUI ui, State state) {
+    public void doCreate(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
 
         Network network = new Network();
@@ -150,46 +138,34 @@ public class NetworkResource extends ComputeResource implements Copyable<Network
         networkRoutingConfig.setRoutingMode(getRoutingMode());
         network.setRoutingConfig(networkRoutingConfig);
 
-        try {
-            Compute.Networks.Insert insert = client.networks().insert(getProjectId(), network);
-            Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
-
-            refresh();
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+        Compute.Networks.Insert insert = client.networks().insert(getProjectId(), network);
+        Operation operation = insert.execute();
+        Operation.Error error = waitForCompletion(client, operation);
+        if (error != null) {
+            throw new GyroException(error.toPrettyString());
         }
+
+        refresh();
     }
 
     @Override
-    public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
+    public void doUpdate(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
         Compute client = createComputeClient();
 
-        try {
-            NetworkRoutingConfig networkRoutingConfig = new NetworkRoutingConfig();
-            networkRoutingConfig.setRoutingMode(getRoutingMode());
+        NetworkRoutingConfig networkRoutingConfig = new NetworkRoutingConfig();
+        networkRoutingConfig.setRoutingMode(getRoutingMode());
 
-            Network network = client.networks().get(getProjectId(), getName()).execute();
-            network.setRoutingConfig(networkRoutingConfig);
+        Network network = client.networks().get(getProjectId(), getName()).execute();
+        network.setRoutingConfig(networkRoutingConfig);
 
-            client.networks().patch(getProjectId(), getName(), network).execute();
-            refresh();
-        } catch (IOException ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
+        client.networks().patch(getProjectId(), getName(), network).execute();
+        refresh();
     }
 
     @Override
-    public void delete(GyroUI ui, State state) {
+    public void doDelete(GyroUI ui, State state) throws Exception {
         Compute compute = createComputeClient();
 
-        try {
-            compute.networks().delete(getProjectId(), getName()).execute();
-        } catch (IOException ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
+        compute.networks().delete(getProjectId(), getName()).execute();
     }
 }

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
@@ -16,17 +16,14 @@
 
 package gyro.google.compute;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.Metadata;
-import gyro.core.GyroException;
-import gyro.core.Type;
-import gyro.google.GoogleFinder;
-
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Metadata;
+import gyro.core.Type;
+import gyro.google.GoogleFinder;
 
 /**
  * Query a project-wide metadata item.
@@ -54,33 +51,21 @@ public class ProjectMetadataItemFinder extends GoogleFinder<Compute, Metadata.It
     }
 
     @Override
-    protected List<Metadata.Items> findAllGoogle(Compute client) {
-        try {
-            return client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems();
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
+    protected List<Metadata.Items> findAllGoogle(Compute client) throws Exception {
+        return client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems();
     }
 
     @Override
-    protected List<Metadata.Items> findGoogle(Compute client, Map<String, String> filters) {
-        try {
-            Metadata.Items item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
-                .filter(r -> filters.get("key").equals(r.getKey()))
-                .findFirst()
-                .orElse(null);
+    protected List<Metadata.Items> findGoogle(Compute client, Map<String, String> filters) throws Exception {
+        Metadata.Items item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
+            .filter(r -> filters.get("key").equals(r.getKey()))
+            .findFirst()
+            .orElse(null);
 
-            if (item != null) {
-                return Collections.singletonList(item);
-            } else {
-                return Collections.emptyList();
-            }
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (IOException ex) {
-            throw new GyroException(ex);
+        if (item != null) {
+            return Collections.singletonList(item);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
@@ -57,7 +57,8 @@ public class ProjectMetadataItemFinder extends GoogleFinder<Compute, Metadata.It
 
     @Override
     protected List<Metadata.Items> findGoogle(Compute client, Map<String, String> filters) throws Exception {
-        Metadata.Items item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems().stream()
+        Metadata.Items item = client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems()
+            .stream()
             .filter(r -> filters.get("key").equals(r.getKey()))
             .findFirst()
             .orElse(null);

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemResource.java
@@ -16,6 +16,9 @@
 
 package gyro.google.compute;
 
+import java.util.List;
+import java.util.Set;
+
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Metadata;
@@ -29,8 +32,6 @@ import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
 import gyro.core.validation.Required;
 import gyro.google.Copyable;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Creates a project-wide metadata item. Set project-wide SSH keys by creating an item with the key ``ssh-keys``.
@@ -81,7 +82,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     }
 
     @Override
-    public boolean refresh() {
+    public boolean doRefresh() throws Exception {
         Compute client = createComputeClient();
 
         Metadata metadata = getMetadata(client);
@@ -101,7 +102,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     }
 
     @Override
-    public void create(GyroUI ui, State state) {
+    public void doCreate(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
 
         Metadata.Items item = new Metadata.Items();
@@ -117,7 +118,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     }
 
     @Override
-    public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
+    public void doUpdate(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
         Compute client = createComputeClient();
 
         Metadata metadata = getMetadata(client);
@@ -134,7 +135,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
     }
 
     @Override
-    public void delete(GyroUI ui, State state) {
+    public void doDelete(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
 
         Metadata metadata = getMetadata(client);
@@ -143,20 +144,14 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
         setMetadata(client, metadata);
     }
 
-    private Metadata getMetadata(Compute client) {
-        try {
-            Compute.Projects.Get projectRequest = client.projects().get(getProjectId());
-            Project project = projectRequest.execute();
+    private Metadata getMetadata(Compute client) throws Exception {
+        Compute.Projects.Get projectRequest = client.projects().get(getProjectId());
+        Project project = projectRequest.execute();
 
-            return project.getCommonInstanceMetadata();
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
+        return project.getCommonInstanceMetadata();
     }
 
-    private void setMetadata(Compute client, Metadata metadata) {
+    private void setMetadata(Compute client, Metadata metadata) throws Exception {
         try {
             Compute.Projects.SetCommonInstanceMetadata metadataRequest =
                 client.projects().setCommonInstanceMetadata(getProjectId(), metadata);
@@ -172,9 +167,7 @@ public class ProjectMetadataItemResource extends ComputeResource implements Copy
                 throw new GyroException(String.format("Duplicate keys: %s", getKey()));
             }
 
-            throw new GyroException(message);
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw je;
         }
     }
 }

--- a/src/main/java/gyro/google/compute/RouteFinder.java
+++ b/src/main/java/gyro/google/compute/RouteFinder.java
@@ -16,18 +16,16 @@
 
 package gyro.google.compute;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.Route;
-import com.google.api.services.compute.model.RouteList;
-import gyro.core.GyroException;
-import gyro.core.Type;
-import gyro.google.GoogleFinder;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Route;
+import com.google.api.services.compute.model.RouteList;
+import gyro.core.Type;
+import gyro.google.GoogleFinder;
 
 /**
  * Query route.
@@ -55,44 +53,22 @@ public class RouteFinder extends GoogleFinder<Compute, Route, RouteResource> {
     }
 
     @Override
-    protected List<Route> findAllGoogle(Compute client) {
-        try {
-            List<Route> routes = new ArrayList<>();
-            RouteList routeList;
-            String nextPageToken = null;
+    protected List<Route> findAllGoogle(Compute client) throws Exception {
+        List<Route> routes = new ArrayList<>();
+        RouteList routeList;
+        String nextPageToken = null;
 
-            do {
-                routeList = client.routes().list(getProjectId()).setPageToken(nextPageToken).execute();
-                routes.addAll(routeList.getItems());
-                nextPageToken = routeList.getNextPageToken();
-            } while (nextPageToken != null);
+        do {
+            routeList = client.routes().list(getProjectId()).setPageToken(nextPageToken).execute();
+            routes.addAll(routeList.getItems());
+            nextPageToken = routeList.getNextPageToken();
+        } while (nextPageToken != null);
 
-            return routes;
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
+        return routes;
     }
 
     @Override
-    protected List<Route> findGoogle(Compute client, Map<String, String> filters) {
-        Route route = null;
-
-        try {
-            route = client.routes().get(getProjectId(), filters.get("name")).execute();
-        } catch (GoogleJsonResponseException je) {
-            if (je.getDetails().getCode() != 404) {
-                throw new GyroException(je.getDetails().getMessage());
-            }
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
-
-        if (route != null) {
-            return Collections.singletonList(route);
-        } else {
-            return Collections.emptyList();
-        }
+    protected List<Route> findGoogle(Compute client, Map<String, String> filters) throws Exception {
+        return Collections.singletonList(client.routes().get(getProjectId(), filters.get("name")).execute());
     }
 }

--- a/src/main/java/gyro/google/compute/RouteResource.java
+++ b/src/main/java/gyro/google/compute/RouteResource.java
@@ -256,7 +256,8 @@ public class RouteResource extends ComputeResource implements Copyable<Route> {
         route = client.routes().get(getProjectId(), getName()).execute();
         copyFrom(route);
         if (route.getWarnings() != null && !route.getWarnings().isEmpty()) {
-            GyroCore.ui().write("@|orange Route created with warnings:|@ %s\n",
+            GyroCore.ui().write(
+                "@|orange Route created with warnings:|@ %s\n",
                 route.getWarnings().stream().map(Route.Warnings::getMessage).collect(Collectors.joining("\n")));
         }
     }

--- a/src/main/java/gyro/google/compute/SubnetworkFinder.java
+++ b/src/main/java/gyro/google/compute/SubnetworkFinder.java
@@ -89,6 +89,7 @@ public class SubnetworkFinder extends GoogleFinder<Compute, Subnetwork, Subnetwo
 
     @Override
     protected List<Subnetwork> findGoogle(Compute client, Map<String, String> filters) throws Exception {
-        return Collections.singletonList(client.subnetworks().get(getProjectId(), filters.get("region"), filters.get("name")).execute());
+        return Collections.singletonList(
+            client.subnetworks().get(getProjectId(), filters.get("region"), filters.get("name")).execute());
     }
 }

--- a/src/main/java/gyro/google/compute/SubnetworkFinder.java
+++ b/src/main/java/gyro/google/compute/SubnetworkFinder.java
@@ -16,16 +16,6 @@
 
 package gyro.google.compute;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.Subnetwork;
-import com.google.api.services.compute.model.SubnetworkAggregatedList;
-import com.google.api.services.compute.model.SubnetworksScopedList;
-import gyro.core.GyroException;
-import gyro.core.Type;
-import gyro.google.GoogleFinder;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +23,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Subnetwork;
+import com.google.api.services.compute.model.SubnetworkAggregatedList;
+import com.google.api.services.compute.model.SubnetworksScopedList;
+import gyro.core.Type;
+import gyro.google.GoogleFinder;
 
 /**
  * Query subnet.
@@ -72,48 +69,26 @@ public class SubnetworkFinder extends GoogleFinder<Compute, Subnetwork, Subnetwo
     }
 
     @Override
-    protected List<Subnetwork> findAllGoogle(Compute client) {
-        try {
-            List<Subnetwork> subnetworks = new ArrayList<>();
-            SubnetworkAggregatedList subnetworkList;
-            String nextPageToken = null;
+    protected List<Subnetwork> findAllGoogle(Compute client) throws Exception {
+        List<Subnetwork> subnetworks = new ArrayList<>();
+        SubnetworkAggregatedList subnetworkList;
+        String nextPageToken = null;
 
-            do {
-                subnetworkList = client.subnetworks().aggregatedList(getProjectId()).setPageToken(nextPageToken).execute();
-                subnetworks.addAll(subnetworkList.getItems().values().stream()
-                    .map(SubnetworksScopedList::getSubnetworks)
-                    .filter(Objects::nonNull)
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toList()));
-                nextPageToken = subnetworkList.getNextPageToken();
-            } while (nextPageToken != null);
+        do {
+            subnetworkList = client.subnetworks().aggregatedList(getProjectId()).setPageToken(nextPageToken).execute();
+            subnetworks.addAll(subnetworkList.getItems().values().stream()
+                .map(SubnetworksScopedList::getSubnetworks)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
+            nextPageToken = subnetworkList.getNextPageToken();
+        } while (nextPageToken != null);
 
-            return subnetworks;
-        } catch (GoogleJsonResponseException je) {
-            throw new GyroException(je.getDetails().getMessage());
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
+        return subnetworks;
     }
 
     @Override
-    protected List<Subnetwork> findGoogle(Compute client, Map<String, String> filters) {
-        Subnetwork subnetwork = null;
-
-        try {
-            subnetwork = client.subnetworks().get(getProjectId(), filters.get("region"), filters.get("name")).execute();
-        } catch (GoogleJsonResponseException je) {
-            if (!je.getDetails().getMessage().matches("The resource (.*) was not found")) {
-                throw new GyroException(je.getDetails().getMessage());
-            }
-        } catch (IOException ex) {
-            throw new GyroException(ex);
-        }
-
-        if (subnetwork != null) {
-            return Collections.singletonList(subnetwork);
-        } else {
-            return Collections.emptyList();
-        }
+    protected List<Subnetwork> findGoogle(Compute client, Map<String, String> filters) throws Exception {
+        return Collections.singletonList(client.subnetworks().get(getProjectId(), filters.get("region"), filters.get("name")).execute());
     }
 }

--- a/src/main/java/gyro/google/compute/SubnetworkResource.java
+++ b/src/main/java/gyro/google/compute/SubnetworkResource.java
@@ -16,10 +16,8 @@
 
 package gyro.google.compute;
 
-import java.io.IOException;
 import java.util.Set;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Subnetwork;
@@ -180,27 +178,17 @@ public class SubnetworkResource extends ComputeResource implements Copyable<Subn
     }
 
     @Override
-    public boolean refresh() {
+    public boolean doRefresh() throws Exception {
         Compute client = createComputeClient();
 
-        try {
-            Subnetwork subnetwork = client.subnetworks().get(getProjectId(), getRegion(), getName()).execute();
-            copyFrom(subnetwork);
+        Subnetwork subnetwork = client.subnetworks().get(getProjectId(), getRegion(), getName()).execute();
+        copyFrom(subnetwork);
 
-            return true;
-        } catch (GoogleJsonResponseException je) {
-            if (je.getDetails().getMessage().matches("The resource (.*) was not found")) {
-                return false;
-            } else {
-                throw new GyroException(je.getDetails().getMessage());
-            }
-        } catch (IOException ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
+        return true;
     }
 
     @Override
-    public void create(GyroUI ui, State state) {
+    public void doCreate(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
 
         Subnetwork subnetwork = new Subnetwork();
@@ -211,54 +199,42 @@ public class SubnetworkResource extends ComputeResource implements Copyable<Subn
         subnetwork.setEnableFlowLogs(getEnableFlowLogs());
         subnetwork.setPrivateIpGoogleAccess(getPrivateIpGoogleAccess());
 
-        try {
-            Compute.Subnetworks.Insert insert = client.subnetworks().insert(getProjectId(), getRegion(), subnetwork);
-            Operation operation = insert.execute();
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
+        Compute.Subnetworks.Insert insert = client.subnetworks().insert(getProjectId(), getRegion(), subnetwork);
+        Operation operation = insert.execute();
+        Operation.Error error = waitForCompletion(client, operation);
+        if (error != null) {
+            throw new GyroException(error.toPrettyString());
+        }
 
-            refresh();
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+        refresh();
+    }
+
+    @Override
+    public void doUpdate(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
+        Compute client = createComputeClient();
+
+        if (changedFieldNames.contains("enable-flow-logs")) {
+            Subnetwork subnetwork = client.subnetworks().get(getProjectId(), getRegion(), getName()).execute();
+            subnetwork.setEnableFlowLogs(getEnableFlowLogs());
+            client.subnetworks().patch(getProjectId(), getRegion(), getName(), subnetwork).execute();
+        }
+
+        if (changedFieldNames.contains("private-ip-google-access")) {
+            SubnetworksSetPrivateIpGoogleAccessRequest flag = new SubnetworksSetPrivateIpGoogleAccessRequest();
+            flag.setPrivateIpGoogleAccess(getPrivateIpGoogleAccess());
+            client.subnetworks().setPrivateIpGoogleAccess(getProjectId(), getRegion(), getName(), flag).execute();
         }
     }
 
     @Override
-    public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
+    public void doDelete(GyroUI ui, State state) throws Exception {
         Compute client = createComputeClient();
 
-        try {
-            if (changedFieldNames.contains("enable-flow-logs")) {
-                Subnetwork subnetwork = client.subnetworks().get(getProjectId(), getRegion(), getName()).execute();
-                subnetwork.setEnableFlowLogs(getEnableFlowLogs());
-                client.subnetworks().patch(getProjectId(), getRegion(), getName(), subnetwork).execute();
-            }
+        Operation operation = client.subnetworks().delete(getProjectId(), getRegion(), getName()).execute();
 
-            if (changedFieldNames.contains("private-ip-google-access")) {
-                SubnetworksSetPrivateIpGoogleAccessRequest flag = new SubnetworksSetPrivateIpGoogleAccessRequest();
-                flag.setPrivateIpGoogleAccess(getPrivateIpGoogleAccess());
-                client.subnetworks().setPrivateIpGoogleAccess(getProjectId(), getRegion(), getName(), flag).execute();
-            }
-        } catch (IOException ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
-        }
-    }
-
-    @Override
-    public void delete(GyroUI ui, State state) {
-        Compute client = createComputeClient();
-
-        try {
-            Operation operation = client.subnetworks().delete(getProjectId(), getRegion(), getName()).execute();
-
-            Operation.Error error = waitForCompletion(client, operation);
-            if (error != null) {
-                throw new GyroException(error.toPrettyString());
-            }
-        } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+        Operation.Error error = waitForCompletion(client, operation);
+        if (error != null) {
+            throw new GyroException(error.toPrettyString());
         }
     }
 }


### PR DESCRIPTION
Fixes #57 

This allows us to no longer have to repeat the same `try/catch` blocks in all of the `refresh`, `create`, `update`, and `delete` methods. It also gives us a standard formatting for the exception messages. If ever we need to go against the standard formatting, simply `throw new GyroException("my_message")` and the exception will not be modified.