### PR TITLE
GCP: Fix GoogleResource#refresh to return false on 404

### DIFF
--- a/src/main/java/gyro/google/GoogleResource.java
+++ b/src/main/java/gyro/google/GoogleResource.java
@@ -52,7 +52,7 @@ public abstract class GoogleResource extends Resource {
         } catch (GyroException ex) {
             throw ex;
         } catch (GoogleJsonResponseException je) {
-            if (je.getDetails().getCode() != 404) {
+            if (je.getDetails().getCode() == 404) {
                 return false;
             } else {
                 throw new GyroException(formatGoogleExceptionMessage(je));


### PR DESCRIPTION
Fixes #57
The 404 check was accidentally flipped when `GoogleResource#refresh` was created. When the code is 404, we want to return `false`, indicating that the resource was not found in the refresh. If the code is anything else, we should throw an exception.