### PR TITLE
Fix GCP: Instance group resource errors out if no instance is associated

### DIFF
--- a/src/main/java/gyro/google/compute/InstanceGroupResource.java
+++ b/src/main/java/gyro/google/compute/InstanceGroupResource.java
@@ -333,10 +333,12 @@ public class InstanceGroupResource extends ComputeResource implements Copyable<I
                 .execute();
             pageToken = results.getNextPageToken();
 
-            current.addAll(results.getItems()
-                .stream()
-                .map(item -> findById(InstanceResource.class, item.getInstance()))
-                .collect(Collectors.toList()));
+            if (results.getItems() != null) {
+                current.addAll(results.getItems()
+                    .stream()
+                    .map(item -> findById(InstanceResource.class, item.getInstance()))
+                    .collect(Collectors.toList()));
+            }
 
         } while (pageToken != null);
 


### PR DESCRIPTION
Fixes #89 
The api call `instanceGroups().listInstances()` returns items as `null` instead of an empty list, whihc causes the NPE.