### PR TITLE
Fix NPE for all list based api calls for compute

### DIFF
--- a/src/main/java/gyro/google/compute/AddressFinder.java
+++ b/src/main/java/gyro/google/compute/AddressFinder.java
@@ -107,7 +107,9 @@ public class AddressFinder extends GoogleFinder<Compute, Address, AddressResourc
                     .execute();
                 pageToken = addressList.getNextPageToken();
 
-                addresses.addAll(addressList.getItems());
+                if (addressList.getItems() != null) {
+                    addresses.addAll(addressList.getItems());
+                }
 
             } while (pageToken != null);
         }

--- a/src/main/java/gyro/google/compute/FirewallFinder.java
+++ b/src/main/java/gyro/google/compute/FirewallFinder.java
@@ -61,8 +61,11 @@ public class FirewallFinder extends GoogleFinder<Compute, Firewall, FirewallReso
 
         do {
             firewallList = client.firewalls().list(getProjectId()).setPageToken(nextPageToken).execute();
-            firewalls.addAll(firewallList.getItems());
             nextPageToken = firewallList.getNextPageToken();
+
+            if (firewallList.getItems() != null) {
+                firewalls.addAll(firewallList.getItems());
+            }
         } while (nextPageToken != null);
 
         return firewalls;

--- a/src/main/java/gyro/google/compute/GlobalAddressFinder.java
+++ b/src/main/java/gyro/google/compute/GlobalAddressFinder.java
@@ -64,8 +64,9 @@ public class GlobalAddressFinder extends GoogleFinder<Compute, Address, GlobalAd
                 .execute();
             pageToken = addressList.getNextPageToken();
 
-            addresses.addAll(addressList.getItems());
-
+            if (addressList.getItems() != null) {
+                addresses.addAll(addressList.getItems());
+            }
         } while (pageToken != null);
 
         return addresses;
@@ -85,8 +86,9 @@ public class GlobalAddressFinder extends GoogleFinder<Compute, Address, GlobalAd
                     .execute();
                 pageToken = addressList.getNextPageToken();
 
-                addresses.addAll(addressList.getItems());
-
+                if (addressList.getItems() != null) {
+                    addresses.addAll(addressList.getItems());
+                }
             } while (pageToken != null);
         }
 

--- a/src/main/java/gyro/google/compute/HealthCheckFinder.java
+++ b/src/main/java/gyro/google/compute/HealthCheckFinder.java
@@ -60,8 +60,11 @@ public class HealthCheckFinder extends GoogleFinder<Compute, HealthCheck, Health
         String nextPageToken = null;
         do {
             healthCheckList = client.healthChecks().list(getProjectId()).setPageToken(nextPageToken).execute();
-            healthChecks.addAll(healthCheckList.getItems());
             nextPageToken = healthCheckList.getNextPageToken();
+
+            if (healthCheckList.getItems() != null) {
+                healthChecks.addAll(healthCheckList.getItems());
+            }
         } while (nextPageToken != null);
 
         return healthChecks;

--- a/src/main/java/gyro/google/compute/ImageFinder.java
+++ b/src/main/java/gyro/google/compute/ImageFinder.java
@@ -118,8 +118,11 @@ public class ImageFinder extends GoogleFinder<Compute, Image, ImageResource> {
 
         do {
             imageList = client.images().list(project).setPageToken(nextPageToken).execute();
-            images.addAll(imageList.getItems().stream().filter(Objects::nonNull).collect(Collectors.toList()));
             nextPageToken = imageList.getNextPageToken();
+
+            if (imageList.getItems() != null) {
+                images.addAll(imageList.getItems().stream().filter(Objects::nonNull).collect(Collectors.toList()));
+            }
         } while (nextPageToken != null);
 
         return images;

--- a/src/main/java/gyro/google/compute/InstanceFinder.java
+++ b/src/main/java/gyro/google/compute/InstanceFinder.java
@@ -19,6 +19,7 @@ package gyro.google.compute;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.api.services.compute.Compute;
@@ -70,10 +71,10 @@ public class InstanceFinder extends GoogleFinder<Compute, Instance, InstanceReso
     protected List<Instance> findAllGoogle(Compute client) throws Exception {
         List<Instance> instances = new ArrayList<>();
         String pageToken;
-        List<String> zones = client.zones().list(getProjectId()).execute().getItems()
-            .stream()
-            .map(Zone::getName)
-            .collect(Collectors.toList());
+        List<Zone> zoneList = Optional.ofNullable(client.zones().list(getProjectId()).execute().getItems()).orElse(new ArrayList<>());
+        List<String> zones = zoneList.stream()
+                .map(Zone::getName)
+                .collect(Collectors.toList());
 
         for (String zone : zones) {
             do {
@@ -105,7 +106,6 @@ public class InstanceFinder extends GoogleFinder<Compute, Instance, InstanceReso
                 if (results.getItems() != null) {
                     instances.addAll(results.getItems());
                 }
-
             } while (pageToken != null);
         }
 

--- a/src/main/java/gyro/google/compute/InstanceFinder.java
+++ b/src/main/java/gyro/google/compute/InstanceFinder.java
@@ -71,10 +71,11 @@ public class InstanceFinder extends GoogleFinder<Compute, Instance, InstanceReso
     protected List<Instance> findAllGoogle(Compute client) throws Exception {
         List<Instance> instances = new ArrayList<>();
         String pageToken;
-        List<Zone> zoneList = Optional.ofNullable(client.zones().list(getProjectId()).execute().getItems()).orElse(new ArrayList<>());
+        List<Zone> zoneList = Optional.ofNullable(client.zones().list(getProjectId()).execute().getItems())
+            .orElse(new ArrayList<>());
         List<String> zones = zoneList.stream()
-                .map(Zone::getName)
-                .collect(Collectors.toList());
+            .map(Zone::getName)
+            .collect(Collectors.toList());
 
         for (String zone : zones) {
             do {

--- a/src/main/java/gyro/google/compute/NetworkFinder.java
+++ b/src/main/java/gyro/google/compute/NetworkFinder.java
@@ -61,8 +61,11 @@ public class NetworkFinder extends GoogleFinder<Compute, Network, NetworkResourc
 
         do {
             networkList = client.networks().list(getProjectId()).setPageToken(nextPageToken).execute();
-            networks.addAll(networkList.getItems());
             nextPageToken = networkList.getNextPageToken();
+
+            if (networkList.getItems() != null) {
+                networks.addAll(networkList.getItems());
+            }
         } while (nextPageToken != null);
 
         return networks;

--- a/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
+++ b/src/main/java/gyro/google/compute/ProjectMetadataItemFinder.java
@@ -56,7 +56,11 @@ public class ProjectMetadataItemFinder extends GoogleFinder<Compute, Metadata.It
 
     @Override
     protected List<Metadata.Items> findAllGoogle(Compute client) throws Exception {
-        return Optional.ofNullable(client.projects().get(getProjectId()).execute().getCommonInstanceMetadata().getItems()).orElse(new ArrayList<>());
+        return Optional.ofNullable(client.projects()
+            .get(getProjectId())
+            .execute()
+            .getCommonInstanceMetadata()
+            .getItems()).orElse(new ArrayList<>());
     }
 
     @Override

--- a/src/main/java/gyro/google/compute/RegionUrlMapFinder.java
+++ b/src/main/java/gyro/google/compute/RegionUrlMapFinder.java
@@ -106,10 +106,13 @@ public class RegionUrlMapFinder extends GoogleFinder<Compute, UrlMap, UrlMapReso
             do {
                 urlMapList =
                     client.regionUrlMaps().list(getProjectId(), getRegion()).setPageToken(nextPageToken).execute();
-                urlMaps.addAll(urlMapList.getItems().stream()
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList()));
                 nextPageToken = urlMapList.getNextPageToken();
+
+                if (urlMapList.getItems() != null) {
+                    urlMaps.addAll(urlMapList.getItems().stream()
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()));
+                }
             } while (nextPageToken != null);
         }
         return urlMaps;

--- a/src/main/java/gyro/google/compute/RegionalHealthCheckFinder.java
+++ b/src/main/java/gyro/google/compute/RegionalHealthCheckFinder.java
@@ -111,7 +111,10 @@ public class RegionalHealthCheckFinder extends GoogleFinder<Compute, HealthCheck
                     .setPageToken(nextPageToken)
                     .execute();
                 nextPageToken = healthCheckList.getNextPageToken();
-                healthChecks.addAll(healthCheckList.getItems());
+
+                if (healthCheckList.getItems() != null) {
+                    healthChecks.addAll(healthCheckList.getItems());
+                }
             } while (nextPageToken != null);
         }
 

--- a/src/main/java/gyro/google/compute/ResourcePolicyFinder.java
+++ b/src/main/java/gyro/google/compute/ResourcePolicyFinder.java
@@ -105,8 +105,9 @@ public class ResourcePolicyFinder extends GoogleFinder<Compute, ResourcePolicy, 
                     .execute();
                 pageToken = policyList.getNextPageToken();
 
-                policies.addAll(policyList.getItems());
-
+                if (policyList.getItems() != null) {
+                    policies.addAll(policyList.getItems());
+                }
             } while (pageToken != null);
         }
 

--- a/src/main/java/gyro/google/compute/RouteFinder.java
+++ b/src/main/java/gyro/google/compute/RouteFinder.java
@@ -61,8 +61,11 @@ public class RouteFinder extends GoogleFinder<Compute, Route, RouteResource> {
 
         do {
             routeList = client.routes().list(getProjectId()).setPageToken(nextPageToken).execute();
-            routes.addAll(routeList.getItems());
             nextPageToken = routeList.getNextPageToken();
+
+            if (routeList.getItems() != null) {
+                routes.addAll(routeList.getItems());
+            }
         } while (nextPageToken != null);
 
         return routes;


### PR DESCRIPTION
Fixes #93 

All places under the compute resource where a list based call is made, there is a possibility of NPE if no resource is present of that type.

Previously the api would return an empty list in the `items` if none was found, but now it returns null which causes the NPE.