### PR TITLE
Convert bucket location to lowercase

### DIFF
--- a/src/main/java/gyro/google/storage/BucketResource.java
+++ b/src/main/java/gyro/google/storage/BucketResource.java
@@ -261,6 +261,10 @@ public class BucketResource extends GoogleResource implements Copyable<Bucket> {
      */
     @Updatable
     public String getLocation() {
+        if (location != null) {
+            location = location.toLowerCase();
+        }
+
         return location;
     }
 


### PR DESCRIPTION
Fixes #110 
The api for storage bucket accepts both upper and lower case, but returns an upper case value, which causes gyro to pick it up as a change, over and over again.