### PR TITLE
Fix: Instance Group Managers not accepted as backends

### DIFF
--- a/examples/compute/backend-service.gyro
+++ b/examples/compute/backend-service.gyro
@@ -60,7 +60,7 @@ google::compute-backend-service backend-service-example
     description: 'backend-service-example-desc'
 
     backend
-        group: $(google::compute-instance-group instance-group-example-backend-service)
+        group: $(google::compute-instance-group instance-group-example-backend-service).self-link
         balancing-mode: "UTILIZATION"
     end
 

--- a/examples/compute/region-backend-service.gyro
+++ b/examples/compute/region-backend-service.gyro
@@ -36,24 +36,24 @@ google::compute-instance-group instance-group-example-regional-backend-service
     end
 end
 
-    google::compute-region-backend-service regional-backend-service-example
-        name: 'regional-backend-service-example'
-        region: "us-central1"
-        description: 'regional-backend-service-example-desc'
+google::compute-region-backend-service regional-backend-service-example
+    name: 'regional-backend-service-example'
+    region: "us-central1"
+    description: 'regional-backend-service-example-desc'
 
-        backend
-            group: $(google::compute-instance-group instance-group-example-regional-backend-service)
-            balancing-mode: "UTILIZATION"
-        end
-
-        health-check: [ $(google::compute-health-check health-check-example-regional-backend-service) ]
-
-        connection-draining
-            draining-timeout-sec: 41
-        end
-
-        load-balancing-scheme: "INTERNAL"
-
-        protocol: "HTTPS"
-        session-affinity: "NONE"
+    backend
+        group: $(google::compute-instance-group instance-group-example-regional-backend-service).self-link
+        balancing-mode: "UTILIZATION"
     end
+
+    health-check: [ $(google::compute-health-check health-check-example-regional-backend-service) ]
+
+    connection-draining
+        draining-timeout-sec: 41
+    end
+
+    load-balancing-scheme: "INTERNAL"
+
+    protocol: "HTTPS"
+    session-affinity: "NONE"
+end

--- a/src/main/java/gyro/google/compute/BackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/BackendServiceResource.java
@@ -47,7 +47,7 @@ import gyro.core.validation.ValidationError;
  *         description: 'backend-service-example-desc'
  *
  *         backend
- *             group: $(google::compute-instance-group instance-group-example-backend-service)
+ *             group: $(google::compute-instance-group instance-group-example-backend-service).self-link
  *         end
  *
  *         health-check: [ $(google::compute-health-check health-check-example-backend-service) ]

--- a/src/main/java/gyro/google/compute/ComputeBackend.java
+++ b/src/main/java/gyro/google/compute/ComputeBackend.java
@@ -17,7 +17,6 @@
 package gyro.google.compute;
 
 import com.google.api.services.compute.model.Backend;
-import com.psddev.dari.util.ObjectUtils;
 import gyro.core.resource.Diffable;
 import gyro.core.resource.Updatable;
 import gyro.core.validation.Required;
@@ -29,7 +28,7 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
     private String balancingMode;
     private Float capacityScaler;
     private String description;
-    private InstanceGroupResource group;
+    private String group;
     private Integer maxConnections;
     private Integer maxConnectionsPerEndpoint;
     private Integer maxConnectionsPerInstance;
@@ -77,14 +76,17 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
     }
 
     /**
-     * The instance group that the backend would be supporting. (Required)
+     * The fully-qualified URL of an instance group or network endpoint group (NEG) resource.
+     * When ``load-balancing-scheme`` is set to either ``EXTERNAL``, ``INTERNAL_SELF_MANAGED``, or
+     * ``INTERNAL_MANAGED``, the group can be a instance group or a NEG. If set to ``INTERNAL``
+     * the group needs to be an instance group in the same region as the backend service.
      */
     @Required
-    public InstanceGroupResource getGroup() {
+    public String getGroup() {
         return group;
     }
 
-    public void setGroup(InstanceGroupResource group) {
+    public void setGroup(String group) {
         this.group = group;
     }
 
@@ -180,12 +182,7 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
         setCapacityScaler(model.getCapacityScaler());
         setDescription(model.getDescription());
         InstanceGroupResource instanceGroup = null;
-        String group = model.getGroup();
-
-        if (group != null) {
-            instanceGroup = findById(InstanceGroupResource.class, group);
-        }
-        setGroup(instanceGroup);
+        setGroup(model.getGroup());
         setMaxConnections(model.getMaxConnections());
         setMaxConnectionsPerEndpoint(model.getMaxConnectionsPerEndpoint());
         setMaxConnectionsPerInstance(model.getMaxConnectionsPerInstance());
@@ -197,19 +194,7 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
 
     @Override
     public String primaryKey() {
-        // When Region InstanceGroup and Network Endpoint Group are added, modify this.
-
-        String primaryKey = "";
-
-        if (getGroup() != null) {
-            if (!ObjectUtils.isBlank(getGroup().getSelfLink())) {
-                primaryKey = String.format("linked to %s", getGroup().getSelfLink());
-            } else {
-                primaryKey = getGroup().getName();
-            }
-        }
-
-        return primaryKey;
+        return String.format("linked to %s", getGroup());
     }
 
     public Backend toBackend() {
@@ -217,7 +202,7 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
         backend.setBalancingMode(getBalancingMode());
         backend.setCapacityScaler(getCapacityScaler());
         backend.setDescription(getDescription());
-        backend.setGroup(getGroup().getSelfLink());
+        backend.setGroup(getGroup());
         backend.setMaxConnections(getMaxConnections());
         backend.setMaxConnectionsPerEndpoint(getMaxConnectionsPerEndpoint());
         backend.setMaxConnectionsPerInstance(getMaxConnectionsPerInstance());

--- a/src/main/java/gyro/google/compute/ComputeBackend.java
+++ b/src/main/java/gyro/google/compute/ComputeBackend.java
@@ -79,7 +79,9 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
      * The fully-qualified URL of an instance group or network endpoint group (NEG) resource.
      * When ``load-balancing-scheme`` is set to either ``EXTERNAL``, ``INTERNAL_SELF_MANAGED``, or
      * ``INTERNAL_MANAGED``, the group can be a instance group or a NEG. If set to ``INTERNAL``
-     * the group needs to be an instance group in the same region as the backend service.
+     * the group needs to be an instance group in the same region as the backend service. When referencing
+     * instance group manager/ region intance group manager, use the attribute ``instance-group-link`` 
+     * instead of ``self-link``.
      */
     @Required
     public String getGroup() {

--- a/src/main/java/gyro/google/compute/RegionBackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/RegionBackendServiceResource.java
@@ -42,7 +42,7 @@ import gyro.core.validation.Required;
  *         description: 'regional-backend-service-example-desc'
  *
  *         backend
- *             group: $(google::compute-instance-group instance-group-example-regional-backend-service)
+ *             group: $(google::compute-instance-group instance-group-example-regional-backend-service).self-link
  *             balancing-mode: "UTILIZATION"
  *         end
  *


### PR DESCRIPTION
Fixes #149 

Changing the attribute `group` type to String makes it more generic
The field can be one of the following:
 - Instance Group
 - region instance group manager
 - instance group manager
 - network end point group

Also for instance group manager and region instance group manager they take in a different field `instance-group-link` as the value instead of their `self-link` which is the (@Id field), making find by id complicated to attain

Having it a String allows it to be set with all those types and the api also complains for wrong value set.