### PR TITLE
Refactor group to be resource reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ configurations {
 
 dependencies {
     api 'gyro:gyro-core:0.99.1-SNAPSHOT'
-    implementation enforcedPlatform('com.google.cloud:libraries-bom:4.2.0')
+    implementation enforcedPlatform('com.google.cloud:libraries-bom:5.3.0')
     implementation 'com.google.auth:google-auth-library-oauth2-http:0.18.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev309-1.25.0'
     implementation 'com.google.apis:google-api-services-cloudresourcemanager:v1-rev20200311-1.30.9'

--- a/examples/compute/backend-service.gyro
+++ b/examples/compute/backend-service.gyro
@@ -60,7 +60,10 @@ google::compute-backend-service backend-service-example
     description: 'backend-service-example-desc'
 
     backend
-        group: $(google::compute-instance-group instance-group-example-backend-service).self-link
+        group
+            instance-group: $(google::compute-instance-group instance-group-example-backend-service)
+        end
+
         balancing-mode: "UTILIZATION"
     end
 

--- a/examples/compute/region-backend-service.gyro
+++ b/examples/compute/region-backend-service.gyro
@@ -42,7 +42,10 @@ google::compute-region-backend-service regional-backend-service-example
     description: 'regional-backend-service-example-desc'
 
     backend
-        group: $(google::compute-instance-group instance-group-example-regional-backend-service).self-link
+        group
+            instance-group: $(google::compute-instance-group instance-group-example-backend-service)
+        end
+
         balancing-mode: "UTILIZATION"
     end
 

--- a/src/main/java/gyro/google/compute/AbstractBackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/AbstractBackendServiceResource.java
@@ -405,4 +405,8 @@ public abstract class AbstractBackendServiceResource extends ComputeResource imp
 
         return backendService;
     }
+
+    String getProject() {
+        return getProjectId();
+    }
 }

--- a/src/main/java/gyro/google/compute/BackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/BackendServiceResource.java
@@ -55,7 +55,9 @@ import gyro.core.validation.ValidationError;
  *         description: 'backend-service-example-desc'
  *
  *         backend
- *             group: $(google::compute-instance-group instance-group-example-backend-service).self-link
+ *             group
+ *                 instance-group: $(google::compute-instance-group instance-group-example-regional-backend-service)
+ *             end
  *         end
  *
  *         health-check: [ $(google::compute-health-check health-check-example-backend-service) ]
@@ -296,7 +298,7 @@ public class BackendServiceResource extends AbstractBackendServiceResource {
 
         for (ComputeBackend backend : getBackend()) {
             ResourceGroupReference resourceGroupReference = new ResourceGroupReference();
-            resourceGroupReference.setGroup(backend.getGroup());
+            resourceGroupReference.setGroup(backend.getGroup().referenceLink());
             List<HealthStatus> healthStatuses;
 
             try {

--- a/src/main/java/gyro/google/compute/BackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/BackendServiceResource.java
@@ -304,7 +304,7 @@ public class BackendServiceResource extends AbstractBackendServiceResource {
             resourceGroupReference.setGroup(backend.getGroup().referenceLink());
             List<HealthStatus> healthStatuses;
             Map<String, Integer> backendHealthMap = new HashMap<>();
-            healthMap.put(backend.getGroup(), backendHealthMap);
+            healthMap.put(backend.getGroup().primaryKey(), backendHealthMap);
 
             try {
                 healthStatuses = Optional.ofNullable(client.backendServices()

--- a/src/main/java/gyro/google/compute/ComputeBackend.java
+++ b/src/main/java/gyro/google/compute/ComputeBackend.java
@@ -16,6 +16,7 @@
 
 package gyro.google.compute;
 
+import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Backend;
 import gyro.core.resource.Diffable;
 import gyro.core.resource.Updatable;
@@ -28,7 +29,7 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
     private String balancingMode;
     private Float capacityScaler;
     private String description;
-    private String group;
+    private ComputeBackendGroup group;
     private Integer maxConnections;
     private Integer maxConnectionsPerEndpoint;
     private Integer maxConnectionsPerInstance;
@@ -84,11 +85,11 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
      * instead of ``self-link``.
      */
     @Required
-    public String getGroup() {
+    public ComputeBackendGroup getGroup() {
         return group;
     }
 
-    public void setGroup(String group) {
+    public void setGroup(ComputeBackendGroup group) {
         this.group = group;
     }
 
@@ -183,8 +184,6 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
         setBalancingMode(model.getBalancingMode());
         setCapacityScaler(model.getCapacityScaler());
         setDescription(model.getDescription());
-        InstanceGroupResource instanceGroup = null;
-        setGroup(model.getGroup());
         setMaxConnections(model.getMaxConnections());
         setMaxConnectionsPerEndpoint(model.getMaxConnectionsPerEndpoint());
         setMaxConnectionsPerInstance(model.getMaxConnectionsPerInstance());
@@ -192,6 +191,10 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
         setMaxRatePerEndpoint(model.getMaxRatePerEndpoint());
         setMaxRatePerInstance(model.getMaxRatePerInstance());
         setMaxUtilization(model.getMaxUtilization());
+
+        ComputeBackendGroup backendGroup = newSubresource(ComputeBackendGroup.class);
+        backendGroup.copyFrom(model.getGroup());
+        setGroup(backendGroup);
     }
 
     @Override
@@ -204,7 +207,7 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
         backend.setBalancingMode(getBalancingMode());
         backend.setCapacityScaler(getCapacityScaler());
         backend.setDescription(getDescription());
-        backend.setGroup(getGroup());
+        backend.setGroup(getGroup().referenceLink());
         backend.setMaxConnections(getMaxConnections());
         backend.setMaxConnectionsPerEndpoint(getMaxConnectionsPerEndpoint());
         backend.setMaxConnectionsPerInstance(getMaxConnectionsPerInstance());
@@ -213,5 +216,17 @@ public class ComputeBackend extends Diffable implements Copyable<Backend> {
         backend.setMaxRatePerInstance(getMaxRatePerInstance());
         backend.setMaxUtilization(getMaxUtilization());
         return backend;
+    }
+
+    Compute getClient() {
+        AbstractBackendServiceResource parent = (AbstractBackendServiceResource) parent();
+
+        return parent.createComputeClient();
+    }
+
+    String getProject() {
+        AbstractBackendServiceResource parent = (AbstractBackendServiceResource) parent();
+
+        return parent.getProject();
     }
 }

--- a/src/main/java/gyro/google/compute/ComputeBackendGroup.java
+++ b/src/main/java/gyro/google/compute/ComputeBackendGroup.java
@@ -66,7 +66,7 @@ public class ComputeBackendGroup extends Diffable implements Copyable<String> {
 
     @Override
     public String primaryKey() {
-        String groupLink;
+        String groupLink = "";
 
         if (getInstanceGroup() != null) {
             groupLink = ObjectUtils.isBlank(getInstanceGroup().getSelfLink())
@@ -76,7 +76,7 @@ public class ComputeBackendGroup extends Diffable implements Copyable<String> {
             groupLink = ObjectUtils.isBlank(getInstanceGroupManager().getSelfLink())
                 ? getInstanceGroupManager().getName()
                 : getInstanceGroupManager().getSelfLink();
-        } else {
+        } else if (getRegionInstanceGroupManager() != null) {
             groupLink = ObjectUtils.isBlank(getRegionInstanceGroupManager().getSelfLink())
                 ? getRegionInstanceGroupManager().getName()
                 : getRegionInstanceGroupManager().getSelfLink();

--- a/src/main/java/gyro/google/compute/ComputeBackendGroup.java
+++ b/src/main/java/gyro/google/compute/ComputeBackendGroup.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.google.compute;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.Compute;
+import com.psddev.dari.util.ObjectUtils;
+import gyro.core.GyroException;
+import gyro.core.resource.Diffable;
+import gyro.core.validation.ConflictsWith;
+import gyro.core.validation.ValidationError;
+import gyro.google.Copyable;
+
+public class ComputeBackendGroup extends Diffable implements Copyable<String> {
+
+    private InstanceGroupResource instanceGroup;
+    private InstanceGroupManagerResource instanceGroupManager;
+    private RegionInstanceGroupManagerResource regionInstanceGroupManager;
+
+    @ConflictsWith({ "instance-group-manager", "region-instance-group-manager" })
+    public InstanceGroupResource getInstanceGroup() {
+        return instanceGroup;
+    }
+
+    public void setInstanceGroup(InstanceGroupResource instanceGroup) {
+        this.instanceGroup = instanceGroup;
+    }
+
+    @ConflictsWith({ "instance-group", "region-instance-group-manager" })
+    public InstanceGroupManagerResource getInstanceGroupManager() {
+        return instanceGroupManager;
+    }
+
+    public void setInstanceGroupManager(InstanceGroupManagerResource instanceGroupManager) {
+        this.instanceGroupManager = instanceGroupManager;
+    }
+
+    @ConflictsWith({ "instance-group-manager", "instance-group" })
+    public RegionInstanceGroupManagerResource getRegionInstanceGroupManager() {
+        return regionInstanceGroupManager;
+    }
+
+    public void setRegionInstanceGroupManager(RegionInstanceGroupManagerResource regionInstanceGroupManager) {
+        this.regionInstanceGroupManager = regionInstanceGroupManager;
+    }
+
+    @Override
+    public String primaryKey() {
+        String groupLink;
+
+        if (getInstanceGroup() != null) {
+            groupLink = ObjectUtils.isBlank(getInstanceGroup().getSelfLink())
+                ? getInstanceGroup().getName()
+                : getInstanceGroup().getSelfLink();
+        } else if (getInstanceGroupManager() != null) {
+            groupLink = ObjectUtils.isBlank(getInstanceGroupManager().getSelfLink())
+                ? getInstanceGroupManager().getName()
+                : getInstanceGroupManager().getSelfLink();
+        } else {
+            groupLink = ObjectUtils.isBlank(getRegionInstanceGroupManager().getSelfLink())
+                ? getRegionInstanceGroupManager().getName()
+                : getRegionInstanceGroupManager().getSelfLink();
+        }
+
+        return groupLink;
+    }
+
+    @Override
+    public void copyFrom(String group) {
+        try {
+            if (group.contains("/regions/")) {
+                setRegionInstanceGroupManager(findById(
+                    RegionInstanceGroupManagerResource.class,
+                    group.replaceFirst("/instanceGroups/", "/instanceGroupManagers/")));
+            } else {
+                String[] groupData = group.split("/zones/");
+                String[] groupDetailData = groupData[1].split("/instanceGroups/");
+
+                if (isInstanceGroupManager(groupDetailData[0], groupDetailData[1])) {
+                    setInstanceGroupManager(findById(
+                        InstanceGroupManagerResource.class,
+                        group.replaceFirst("/instanceGroups/", "/instanceGroupManagers/")));
+                } else {
+                    setInstanceGroup(findById(InstanceGroupResource.class, group));
+                }
+            }
+        } catch (Exception ex) {
+            throw new GyroException(ex);
+        }
+    }
+
+    private boolean isInstanceGroupManager(String zone, String name) {
+        ComputeBackend parent = (ComputeBackend) parent();
+        Compute client = parent.getClient();
+        String project = parent.getProject();
+
+        try {
+            client.instanceGroupManagers()
+                .get(project, zone, name)
+                .execute();
+
+            return true;
+        } catch (GyroException ex) {
+            throw ex;
+        } catch (GoogleJsonResponseException je) {
+            if (je.getStatusCode() == 404 || (je.getDetails() != null && je.getDetails().getCode() == 404)) {
+                return false;
+            } else {
+                throw new GyroException(je);
+            }
+        } catch (Exception ex) {
+            throw new GyroException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    @Override
+    public List<ValidationError> validate(Set<String> configuredFields) {
+        List<ValidationError> errors = new ArrayList<>();
+
+        if (Stream.of(getInstanceGroup(), getInstanceGroupManager(), getRegionInstanceGroupManager())
+            .allMatch(Objects::isNull)) {
+            errors.add(new ValidationError(
+                this,
+                null,
+                "One of 'instance-group' or 'instance-group-manager' or 'region-instance-group-manager' is required!"));
+        }
+
+        return errors;
+    }
+
+    String referenceLink() {
+        String referenceLink;
+
+        if (getInstanceGroup() != null) {
+            referenceLink = getInstanceGroup().getSelfLink();
+        } else if (getInstanceGroupManager() != null) {
+            referenceLink = getInstanceGroupManager().getInstanceGroupLink();
+        } else {
+            referenceLink = getRegionInstanceGroupManager().getInstanceGroupLink();
+        }
+
+        return referenceLink;
+    }
+}

--- a/src/main/java/gyro/google/compute/RegionBackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/RegionBackendServiceResource.java
@@ -51,7 +51,10 @@ import gyro.core.validation.Required;
  *         description: 'regional-backend-service-example-desc'
  *
  *         backend
- *             group: $(google::compute-instance-group instance-group-example-regional-backend-service).self-link
+ *             group
+ *                 instance-group: $(google::compute-instance-group instance-group-example-regional-backend-service)
+ *             end
+ *
  *             balancing-mode: "UTILIZATION"
  *         end
  *
@@ -131,7 +134,7 @@ public class RegionBackendServiceResource extends AbstractBackendServiceResource
 
         for (ComputeBackend backend : getBackend()) {
             ResourceGroupReference resourceGroupReference = new ResourceGroupReference();
-            resourceGroupReference.setGroup(backend.getGroup());
+            resourceGroupReference.setGroup(backend.getGroup().referenceLink());
             List<HealthStatus> healthStatuses;
 
             try {

--- a/src/main/java/gyro/google/compute/RegionBackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/RegionBackendServiceResource.java
@@ -140,7 +140,7 @@ public class RegionBackendServiceResource extends AbstractBackendServiceResource
             resourceGroupReference.setGroup(backend.getGroup().referenceLink());
             List<HealthStatus> healthStatuses;
             Map<String, Integer> backendHealthMap = new HashMap<>();
-            healthMap.put(backend.getGroup(), backendHealthMap);
+            healthMap.put(backend.getGroup().primaryKey(), backendHealthMap);
 
             try {
                 healthStatuses = Optional.ofNullable(client.regionBackendServices()

--- a/src/main/java/gyro/google/compute/RouterNat.java
+++ b/src/main/java/gyro/google/compute/RouterNat.java
@@ -201,9 +201,13 @@ public class RouterNat extends Diffable implements Copyable<com.google.api.servi
     @Override
     public void copyFrom(com.google.api.services.compute.model.RouterNat model) throws Exception {
         setIcmpIdleTimeoutSec(model.getIcmpIdleTimeoutSec());
-        RouterNatLogConfig logConfig = newSubresource(RouterNatLogConfig.class);
-        logConfig.copyFrom(model.getLogConfig());
-        setLogConfig(logConfig);
+
+        if (model.getLogConfig() != null) {
+            RouterNatLogConfig logConfig = newSubresource(RouterNatLogConfig.class);
+            logConfig.copyFrom(model.getLogConfig());
+            setLogConfig(logConfig);
+        }
+
         setMinPortsPerVm(model.getMinPortsPerVm());
         setName(model.getName());
         setIpAllocationOption(model.getNatIpAllocateOption());


### PR DESCRIPTION
Fixes #168 

The `group` field part of the backend service was a string to facilitate referencing instance-group, instance-manager-group and region-instance-manager-group resources.

This caused some dependency issues when deleting the backend service

The applied approach figures out what the references are and attaches them as direct resource attachment.