### PR TITLE
Allow health monitoring of specific backends in a given backend compute service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ NEW FEATURES:
 * [24](https://github.com/perfectsense/gyro-google-provider/issues/24): Add Firewall Rule.
 * [16](https://github.com/perfectsense/gyro-google-provider/issues/16): Add Bucket.
 * [22](https://github.com/perfectsense/gyro-google-provider/issues/22): Add Instance.
+* [179](https://github.com/perfectsense/gyro-google-provider/issues/179): Report instance health per backend

--- a/src/main/java/gyro/google/compute/BackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/BackendServiceResource.java
@@ -288,16 +288,21 @@ public class BackendServiceResource extends AbstractBackendServiceResource {
         return errors;
     }
 
-    public Map<String, Integer> instanceHealth() {
-        Map<String, Integer> healthMap = new HashMap<>();
-        int total = 0;
+    public Map<String, Map<String, Integer>> instanceHealth() {
+        Map<String, Map<String, Integer>> healthMap = new HashMap<>();
+        Map<String, Integer> allHealthMap = new HashMap<>();
+        healthMap.put("all", allHealthMap);
+        int allTotal = 0;
 
         Compute client = createComputeClient();
 
         for (ComputeBackend backend : getBackend()) {
+            int backendTotal = 0;
             ResourceGroupReference resourceGroupReference = new ResourceGroupReference();
             resourceGroupReference.setGroup(backend.getGroup());
             List<HealthStatus> healthStatuses;
+            Map<String, Integer> backendHealthMap = new HashMap<>();
+            healthMap.put(backend.getGroup(), backendHealthMap);
 
             try {
                 healthStatuses = Optional.ofNullable(client.backendServices()
@@ -310,13 +315,19 @@ public class BackendServiceResource extends AbstractBackendServiceResource {
             }
 
             for (HealthStatus healthStatus : healthStatuses) {
-                int count = healthMap.getOrDefault(healthStatus.getHealthState(), 0);
-                healthMap.put(healthStatus.getHealthState(), count + 1);
-                total++;
+                int backendCount = backendHealthMap.getOrDefault(healthStatus.getHealthState(), 0);
+                backendHealthMap.put(healthStatus.getHealthState(), backendCount + 1);
+                backendTotal++;
+
+                int allCount = allHealthMap.getOrDefault(healthStatus.getHealthState(), 0);
+                allHealthMap.put(healthStatus.getHealthState(), allCount + 1);
+                allTotal++;
             }
+
+            backendHealthMap.put("Total", backendTotal);
         }
 
-        healthMap.put("Total", total);
+        allHealthMap.put("Total", allTotal);
         return healthMap;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/perfectsense/gyro-google-provider/issues/179

A new backend added to an existing backend compute service will initially report as 0 instances healthy and 0 instances total. The current instance health method will be unchanged before adding this new backend and after.

This PR updates the instance health method to report health of each backend service individually as well as the cumulative total.