### PR TITLE
Fix null when NPE occurs

### DIFF
--- a/src/main/java/gyro/google/GoogleFinder.java
+++ b/src/main/java/gyro/google/GoogleFinder.java
@@ -44,7 +44,7 @@ public abstract class GoogleFinder<C, M, R extends GoogleResource> extends Finde
         } catch (GoogleJsonResponseException je) {
             throw new GyroException(GoogleResource.formatGoogleExceptionMessage(je));
         } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw new GyroException(ex);
         }
     }
 
@@ -63,7 +63,7 @@ public abstract class GoogleFinder<C, M, R extends GoogleResource> extends Finde
                 throw new GyroException(GoogleResource.formatGoogleExceptionMessage(je));
             }
         } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw new GyroException(ex);
         }
     }
 
@@ -87,7 +87,7 @@ public abstract class GoogleFinder<C, M, R extends GoogleResource> extends Finde
             } catch (GoogleJsonResponseException je) {
                 throw new GyroException(GoogleResource.formatGoogleExceptionMessage(je));
             } catch (Exception ex) {
-                throw new GyroException(ex.getMessage(), ex.getCause());
+                throw new GyroException(ex);
             }
         }
 

--- a/src/main/java/gyro/google/GoogleResource.java
+++ b/src/main/java/gyro/google/GoogleResource.java
@@ -57,7 +57,7 @@ public abstract class GoogleResource extends Resource {
                 throw new GyroException(formatGoogleExceptionMessage(je));
             }
         } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw new GyroException(ex);
         }
     }
 
@@ -72,7 +72,7 @@ public abstract class GoogleResource extends Resource {
         } catch (GoogleJsonResponseException je) {
             throw new GyroException(formatGoogleExceptionMessage(je));
         } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw new GyroException(ex);
         }
     }
 
@@ -88,7 +88,7 @@ public abstract class GoogleResource extends Resource {
         } catch (GoogleJsonResponseException je) {
             throw new GyroException(formatGoogleExceptionMessage(je));
         } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw new GyroException(ex);
         }
     }
 
@@ -103,7 +103,7 @@ public abstract class GoogleResource extends Resource {
         } catch (GoogleJsonResponseException je) {
             throw new GyroException(formatGoogleExceptionMessage(je));
         } catch (Exception ex) {
-            throw new GyroException(ex.getMessage(), ex.getCause());
+            throw new GyroException(ex);
         }
     }
 


### PR DESCRIPTION
Fixes #183 

When catching generic exception just wrap the whole exception in gyro exception and throw