### PR TITLE
Do not call updateMaster after cluster creation

### DIFF
--- a/src/main/java/gyro/google/gke/ClusterResource.java
+++ b/src/main/java/gyro/google/gke/ClusterResource.java
@@ -1171,15 +1171,6 @@ public class ClusterResource extends GoogleResource implements Copyable<Cluster>
             state.save();
 
             waitForActiveStatus(client);
-
-            if (getMasterVersion() != null) {
-                client.updateMaster(UpdateMasterRequest.newBuilder()
-                    .setName(getClusterId())
-                    .setMasterVersion(getMasterVersion())
-                    .build());
-            }
-
-            waitForActiveStatus(client);
         }
 
         state.save();


### PR DESCRIPTION
This isn't necessary and increases the time to create a cluster significantly.