### PR TITLE
Remove cdn with security policy validation

### DIFF
--- a/src/main/java/gyro/google/compute/BackendServiceResource.java
+++ b/src/main/java/gyro/google/compute/BackendServiceResource.java
@@ -44,7 +44,6 @@ import gyro.core.Type;
 import gyro.core.resource.Resource;
 import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
-import gyro.core.validation.ValidationError;
 
 /**
  * Creates a backend service.
@@ -130,7 +129,7 @@ public class BackendServiceResource extends AbstractBackendServiceResource {
     }
 
     /**
-     * The security policy associated with this backend service. This can only be added when ``enableCdn`` is ``false``.
+     * The security policy associated with this backend service.
      */
     @Updatable
     public SecurityPolicyResource getSecurityPolicy() {
@@ -317,19 +316,6 @@ public class BackendServiceResource extends AbstractBackendServiceResource {
 
             waitForCompletion(response);
         }
-    }
-
-    @Override
-    public List<ValidationError> validate(Set<String> configuredFields) {
-        List<ValidationError> errors = new ArrayList<>();
-        if (getEnableCdn() != null && getEnableCdn().equals(Boolean.TRUE) && getSecurityPolicy() != null) {
-            errors.add(new ValidationError(
-                this,
-                "enable-cdn",
-                "'enable-cdn' can't be true when a security policy is provided."));
-        }
-
-        return errors;
     }
 
     private void saveSecurityPolicy(BackendServicesClient client) throws Exception {


### PR DESCRIPTION
Allows a backend service to have cdn enabled as well as security-policy configured